### PR TITLE
Remove useless redirect

### DIFF
--- a/Tweak/Tweak.xm
+++ b/Tweak/Tweak.xm
@@ -172,7 +172,7 @@ NSString *translationLanguage;
         @"TranslationService": @"https://translate.google.com/?vi=c#auto/%l/%s",
         @"SearchEnabled": @YES,
         @"SearchPopup": @NO,
-        @"SearchEngine": @"https://encrypted.google.com/search?q=%s",
+        @"SearchEngine": @"https://www.google.com/search?q=%s",
     }];
 
     [preferences registerBool:&enabled default:YES forKey:@"Enabled"];


### PR DESCRIPTION
Extremely marginal difference in load time but still a tad quicker to just skip the redirect

Not sure if you had a specific reason for this but the entire point of this endpoint was to point to HTTPS back in the day, now though Google is HSTS and always forced HTTPS. 